### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.0.6
 - Use fixed websocket register path `_ws` for the client to register to the server, remove parameter `wsRegister` in the NewServer function
 - Add parameter `logDir` in the NewClient function, put `appName` in the first place
-
+- Fix gin handler, fix gin route conflict
 ## 0.0.5
 - Modify the registry schema with JSON format. So, it does not support the old schema anymore.
 - Upgrade go version to 1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+- Use fixed websocket register path `_ws` for the client to register to the server, remove parameter `wsRegister` in the NewServer function
+- Add parameter `logDir` in the NewClient function, put `appName` in the first place
+
 ## 0.0.5
 - Modify the registry schema with JSON format. So, it does not support the old schema anymore.
 - Upgrade go version to 1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.0.6
 - Use fixed websocket register path `_ws` for the client to register to the server, remove parameter `wsRegister` in the NewServer function
 - Add parameter `logDir` in the NewClient function, put `appName` in the first place
-- Fix gin handler, fix gin route conflict
+- fix gin route conflict with the static file, use gin handler
 ## 0.0.5
 - Modify the registry schema with JSON format. So, it does not support the old schema anymore.
 - Upgrade go version to 1.20

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ func main() {
 		// you can add more account here		
 	}
 	// authMap can be nil if you don't need auth
-	server := fsearch.NewServer( "/", "/wsRegister", authMap)
+	server := fsearch.NewServer( "/",  authMap)
 	log.Println("server start: 9097")
 	// the dir is that you download and unzip above 
 	staticWebFile := http.Dir("web")

--- a/client.go
+++ b/client.go
@@ -73,8 +73,9 @@ func (c *Client) register(addr string, appName string, hostName string) {
 	// use time.Ticker to replace time.Sleep
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
-	for range ticker.C {
+	for {
 		c.forWS(addr, appName, hostName)
+		<-ticker.C
 	}
 
 }

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type Client struct {
 }
 
 // NewClient Create a new client. dir is the directory to be searched. appName is the name of the application.
-func NewClient(searchTargetDir string, appName string) (*Client, error) {
+func NewClient(appName, searchTargetDir string) (*Client, error) {
 	if len(appName) == 0 {
 		panic("appName can not be empty")
 	}
@@ -43,6 +43,8 @@ func NewClient(searchTargetDir string, appName string) (*Client, error) {
 }
 
 // RegisterToCenter register to center. wsAddr is the address of the center.
+// wsAddr is the address of the center, whose format is ws://host:port+<serverIndexPath>+_ws
+// for example, serverIndexPath is /, then wsAddr is ws://host:port/_ws
 func (c *Client) RegisterToCenter(wsAddr string) {
 	go c.register(wsAddr, c.appName, c.hostName)
 }

--- a/color_html.go
+++ b/color_html.go
@@ -36,23 +36,21 @@ func getLevelColor(level string) (string, bool) {
 
 const replaceTraceId = "TRACE_ID"
 
-func WriteColorHTML(isHref bool, overflowX string, normalColor string, fontSize int64, traceIdHref string, src io.Reader, dst io.Writer) error {
+func WriteColorHTML(isHref bool, normalColor string, fontSize int64, traceIdHref string, src io.Reader, dst io.Writer) error {
 	// 读取文件内容
 	scanner := bufio.NewScanner(src)
 	var buf bytes.Buffer
 	if isHref {
-		if overflowX != "" {
-			buf.Write([]byte(fmt.Sprintf("overflow-x: %s;", overflowX)))
-		}
+		//word-wrap:break-word;
+		buf.Write([]byte("word-wrap:break-word;"))
 		if fontSize > 0 {
 			buf.Write([]byte(fmt.Sprintf("font-size: %dpx;", fontSize)))
 		}
 		if normalColor != "" {
 			buf.Write([]byte(fmt.Sprintf("color: %s;", normalColor)))
 		}
-
 	}
-	_, err := dst.Write([]byte(fmt.Sprintf(`<div id="container" style="%s">`, buf.String())))
+	_, err := dst.Write([]byte(fmt.Sprintf(`<div id="fsearch" style="%s ">`, buf.String())))
 	if err != nil {
 		return err
 	}

--- a/example/example.go
+++ b/example/example.go
@@ -28,11 +28,11 @@ func main() {
 func clientRegister() {
 	appName := "demoApp"
 	searchDir := "../testdata" // can be any directory, especially for logs/
-	cli, err := fsearch.NewClient(searchDir, appName)
+	cli, err := fsearch.NewClient(appName, searchDir)
 	if err != nil {
 		panic(err)
 	}
-	centerWSAddr := "ws://127.0.0.1:9097/ws"
+	centerWSAddr := "ws://127.0.0.1:9097/_ws"
 	cli.RegisterToCenter(centerWSAddr)
 	// use http to search, param is kw and files, multi kw and multi files are supported
 	// query: kw, files, maxLines
@@ -52,7 +52,6 @@ func clientRegister() {
 
 // serverStart start server.
 func serverStart() {
-	wsRegisterPath := "/ws" // the path that client register to: ws://127.0.0.1:9097/ws
 	var indexPath string
 	indexPath = "/" // index path must end with /, usually it's a single slash /
 	//indexPath = "/" // index path must end with /
@@ -67,7 +66,7 @@ func serverStart() {
 	//}
 	//authMap can be nil, if it's nil, no auth is required
 	// if excludedAppNames is not nil, then it will be used to exclude some appNames
-	server := fsearch.NewServer(indexPath, wsRegisterPath, authMap)
+	server := fsearch.NewServer(indexPath, authMap)
 	//wget https://github.com/vito-go/fsearch_flutter/releases/download/v0.0.2/web.zip
 	//unzip web.zip
 	// the staticDir is that you download and unzip above, more details in README.md

--- a/server.go
+++ b/server.go
@@ -64,8 +64,8 @@ func (a *AccountConfig) CheckAppName(appName string) bool {
 var accountConfigNoAuth = &AccountConfig{Username: "_", Password: "_", AllowedAppNames: nil, ExcludedAppNames: nil}
 
 const (
-	searchPathSuffix = "search"
-	wsRegisterSuffix = "ws"
+	searchPathSuffix = "_search"
+	wsRegisterSuffix = "_ws"
 )
 
 // NewServer create a new fsearch server. searchPath is the search path. indexPath is the static file path, it must end with /.


### PR DESCRIPTION
## 0.0.6
- Use fixed websocket register path `_ws` for the client to register to the server, remove parameter `wsRegister` in the NewServer function
- Add parameter `logDir` in the NewClient function, put `appName` in the first place
- fix gin route conflict with the static file, use gin handler